### PR TITLE
libattopng_save(): return 0 on success.

### DIFF
--- a/libattopng.c
+++ b/libattopng.c
@@ -397,7 +397,7 @@ int libattopng_save(libattopng_t *png, const char *filename) {
     if (!f) {
         return 1;
     }
-    if (fwrite(data, len, 1, f) != len) {
+    if (fwrite(data, len, 1, f) != 1) {
         fclose(f);
         return 1;
     }


### PR DESCRIPTION
The current `libattopng_save()` function always returns 1 (=error), even if write was successful.
`fwrite()` returns count of written items (=1).
