### PR TITLE
Update libattopng.c

### DIFF
--- a/libattopng.c
+++ b/libattopng.c
@@ -183,10 +183,8 @@ static uint32_t libattopng_crc(const unsigned char *data, size_t len, uint32_t c
 
 /* ------------------------------------------------------------------------ */
 static void libattopng_out_raw_write(libattopng_t *png, const char *data, size_t len) {
-    size_t i;
-    for (i = 0; i < len; i++) {
-        png->out[png->out_pos++] = data[i];
-    }
+    memcpy(png->out+png->out_pos, data, len);
+    png->out_pos+=len;
 }
 
 /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
Brought over commit by @nevergarden that replaces a loop-based data copy of one-by-one bytes with a call to memcpy to copy all the bytes at once