### PR TITLE
Update libattopng.c

### DIFF
--- a/libattopng.c
+++ b/libattopng.c
@@ -81,7 +81,9 @@ libattopng_t *libattopng_new(size_t width, size_t height, libattopng_type_t type
 
     png->data = (char *) calloc(png->capacity, 1);
     if (!png->data) {
-        free(png->palette);
+        if (png->palette) {
+            free(png->palette);
+        }
         free(png);
         return NULL;
     }


### PR DESCRIPTION
in libattopng_new:
    if png->data allocation fails, should only attempt to free png->palette if it was actually allocated;
    which only happens when type == PNG_PALETTE. 
    Otherwise, especially because line 54 has png->palette = NULL, we risk passing a NULL-pointer to free