### PR TITLE
Update libattopng_put_pixel in libattopng.c

### DIFF
--- a/libattopng.c
+++ b/libattopng.c
@@ -145,6 +145,10 @@ void libattopng_put_pixel(libattopng_t* png, uint32_t color) {
     }
     x = png->stream_x;
     y = png->stream_y;
+    if ((png->capacity - 1) < (x + y * png->width)) {
+            /* ensure we don't attempt an out of bounds memory write */
+            return;
+    }
     if (png->type == PNG_PALETTE || png->type == PNG_GRAYSCALE) {
         png->data[x + y * png->width] = (char) (color & 0xff);
     } else if (png->type == PNG_GRAYSCALE_ALPHA) {


### PR DESCRIPTION
I don't know under what circumstance someone might attempt to change png->stream_x or stream_y to allow for an out-of-bounds write, but the testing of x >= png->width further down could just test if x = png->width if it weren't possible for x to have already been equal to png->width prior to x++, and therefore, out of the same caution showed in the existing code, a bounds check was added prior to any possible writes into the png->data array.