### PR TITLE
Update libattopng_get_data in libattopng.c

### DIFF
--- a/libattopng.c
+++ b/libattopng.c
@@ -276,6 +276,7 @@ char *libattopng_get_data(libattopng_t *png, size_t *len) {
     if (png->out) {
         /* delete old output if any */
         free(png->out);
+        png->out = NULL;
     }
     png->out_capacity = png->capacity + 4096 * 8 + png->width * png->height;
     png->out = (char *) calloc(png->out_capacity, 1);


### PR DESCRIPTION
After any potentially existing "old output" has had it's memory allocation free'd, the reference needs to be set to NULL, so that further operations which may test the reference for whatever purpose wont proceed under faulty assumptions.