### PR TITLE
Update to libattopng_save in libattopng.c

### DIFF
--- a/libattopng.c
+++ b/libattopng.c
@@ -386,10 +386,12 @@ int libattopng_save(libattopng_t *png, const char *filename) {
     }
     f = fopen(filename, "wb");
     if (!f) {
+        fprintf(stderr, "[libattopng] ERROR: opening file \'%s\'; please check file, and try again\n", filename);
         return 1;
     }
     if (fwrite(data, len, 1, f) != 1) {
         fclose(f);
+        fprintf(stderr, "[libattopng] ERROR: writing to file \'%s\'; please check disk, and try again\n", filename);
         return 1;
     }
     fclose(f);


### PR DESCRIPTION
Because failure of the call to libattopng_get_data will already produce verbose output to stderr in the first possible failure situation, matching stderr output was added to the 2 other possible failure situations.