### PR TITLE
refactored libattopng_new in libattopng.c

### DIFF
--- a/libattopng.c
+++ b/libattopng.c
@@ -59,24 +59,30 @@ libattopng_t *libattopng_new(size_t width, size_t height, libattopng_type_t type
     png->stream_x = 0;
     png->stream_y = 0;
 
-    if (type == PNG_PALETTE) {
-        png->palette = (uint32_t *) calloc(256, sizeof(uint32_t));
-        if (!png->palette) {
-            free(png);
-            return NULL;
-        }
-        png->bpp = 1;
-    } else if (type == PNG_GRAYSCALE) {
-        png->bpp = 1;
-    } else if (type == PNG_GRAYSCALE_ALPHA) {
-        png->capacity *= 2;
-        png->bpp = 2;
-    } else if (type == PNG_RGB) {
-        png->capacity *= 4;
-        png->bpp = 3;
-    } else if (type == PNG_RGBA) {
-        png->capacity *= 4;
-        png->bpp = 4;
+    switch (type) {
+        case PNG_PALETTE:
+            png->palette = (uint32_t *) calloc(256, sizeof(uint32_t));
+            if (!png->palette) {
+                free(png);
+                return NULL;
+            }
+            png->bpp = 1;
+            break;
+        case PNG_GRAYSCALE:
+            png->bpp = 1;
+            break;
+        case PNG_GRAYSCALE_ALPHA:
+            png->capacity *= 2;
+            png->bpp = 2;
+            break;
+        case PNG_RGB:
+            png->capacity *= 4;
+            png->bpp = 3;
+            break;
+        case PNG_RGBA:
+            png->capacity *= 4;
+            png->bpp = 4;
+            break;
     }
 
     png->data = (char *) calloc(png->capacity, 1);


### PR DESCRIPTION
Originally, the code had a series of 5 conditional tests, which are performed sequentially and which also do not have a general 'else' case.

This was refactored into a switch block having 5 cases, with no general 'default' case.

Instead of performing a worst case of O(n) comparison operations, the new code performs O(1) operations to calculate the offset for a jumptable; this not only reduces the number of base operations required in all but the best case (providing speed-up), but also reduces the size of the resultant binary.