### PR TITLE
Bash script to build, make, and compile test.c

### DIFF
--- a/compile_test.sh
+++ b/compile_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir build
+cd build/
+cmake ../
+make all
+
+mv libattopng ../libattopng


### PR DESCRIPTION
Simplifies the process of showing off test program with a simple bash script that:
- creates ./build directory
- runs cmake to generate make files into the build directory
- makes all generated targets
- moves compiled libattopng binary from ./build into project root dir (./)