### PR TITLE
Update test.c

### DIFF
--- a/compile_test.sh
+++ b/compile_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir build
+cd build/
+cmake ../
+make all
+
+mv libattopng ../libattopng

--- a/libattopng.c
+++ b/libattopng.c
@@ -183,10 +183,8 @@ static uint32_t libattopng_crc(const unsigned char *data, size_t len, uint32_t c
 
 /* ------------------------------------------------------------------------ */
 static void libattopng_out_raw_write(libattopng_t *png, const char *data, size_t len) {
-    size_t i;
-    for (i = 0; i < len; i++) {
-        png->out[png->out_pos++] = data[i];
-    }
+    memcpy(png->out+png->out_pos, data, len);
+    png->out_pos+=len;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/libattopng.c
+++ b/libattopng.c
@@ -59,24 +59,30 @@ libattopng_t *libattopng_new(size_t width, size_t height, libattopng_type_t type
     png->stream_x = 0;
     png->stream_y = 0;
 
-    if (type == PNG_PALETTE) {
-        png->palette = (uint32_t *) calloc(256, sizeof(uint32_t));
-        if (!png->palette) {
-            free(png);
-            return NULL;
-        }
-        png->bpp = 1;
-    } else if (type == PNG_GRAYSCALE) {
-        png->bpp = 1;
-    } else if (type == PNG_GRAYSCALE_ALPHA) {
-        png->capacity *= 2;
-        png->bpp = 2;
-    } else if (type == PNG_RGB) {
-        png->capacity *= 4;
-        png->bpp = 3;
-    } else if (type == PNG_RGBA) {
-        png->capacity *= 4;
-        png->bpp = 4;
+    switch (type) {
+        case PNG_PALETTE:
+            png->palette = (uint32_t *) calloc(256, sizeof(uint32_t));
+            if (!png->palette) {
+                free(png);
+                return NULL;
+            }
+            png->bpp = 1;
+            break;
+        case PNG_GRAYSCALE:
+            png->bpp = 1;
+            break;
+        case PNG_GRAYSCALE_ALPHA:
+            png->capacity *= 2;
+            png->bpp = 2;
+            break;
+        case PNG_RGB:
+            png->capacity *= 4;
+            png->bpp = 3;
+            break;
+        case PNG_RGBA:
+            png->capacity *= 4;
+            png->bpp = 4;
+            break;
     }
 
     png->data = (char *) calloc(png->capacity, 1);

--- a/libattopng.c
+++ b/libattopng.c
@@ -198,52 +198,38 @@ static void libattopng_out_raw_write(libattopng_t *png, const char *data, size_t
 }
 
 /* ------------------------------------------------------------------------ */
-static void libattopng_out_raw_uint(libattopng_t *png, uint32_t val) {
-    *(uint32_t *) (png->out + png->out_pos) = val;
-    png->out_pos += 4;
-}
-
-/* ------------------------------------------------------------------------ */
-static void libattopng_out_raw_uint16(libattopng_t *png, uint16_t val) {
-    *(uint16_t *) (png->out + png->out_pos) = val;
-    png->out_pos += 2;
-}
-
-/* ------------------------------------------------------------------------ */
-static void libattopng_out_raw_uint8(libattopng_t *png, uint8_t val) {
-    *(uint8_t *) (png->out + png->out_pos) = val;
-    png->out_pos++;
+static void libattopng_out_raw_size_t(libattopng_t* png, size_t val, size_t byte_count) {
+    switch (byte_count) {
+        case 4: //libattopng_out_raw_uint(libattopng_t* png, uint32_t val)
+            *(uint32_t*) (png->out + png->out_pos) = (uint32_t)(val & 0xffffffff);
+            break;
+        case 2: //libattopng_out_raw_uint16(libattopng_t* png, uint16_t val)
+            *(uint16_t*) (png->out + png->out_pos) = (uint16_t)(val & 0xffff);
+            break;
+        case 1: //libattopng_out_raw_uint8(libattopng_t* png, uint8_t val)
+            *(uint8_t*) (png->out + png->out_pos) = (uint8_t)(val & 0xff);
+    }
+    png->out_pos += byte_count;
 }
 
 /* ------------------------------------------------------------------------ */
 static void libattopng_new_chunk(libattopng_t *png, const char *name, size_t len) {
     png->crc = 0xffffffff;
-    libattopng_out_raw_uint(png, libattopng_swap32((uint32_t) len));
+    libattopng_out_raw_size_t(png, libattopng_swap32((uint32_t) len), 4);
     png->crc = libattopng_crc((const unsigned char *) name, 4, png->crc);
     libattopng_out_raw_write(png, name, 4);
 }
 
 /* ------------------------------------------------------------------------ */
 static void libattopng_end_chunk(libattopng_t *png) {
-    libattopng_out_raw_uint(png, libattopng_swap32(~png->crc));
+    libattopng_out_raw_size_t(png, libattopng_swap32(~png->crc), 4);
 }
 
 /* ------------------------------------------------------------------------ */
-static void libattopng_out_uint32(libattopng_t *png, uint32_t val) {
-    png->crc = libattopng_crc((const unsigned char *) &val, 4, png->crc);
-    libattopng_out_raw_uint(png, val);
-}
-
-/* ------------------------------------------------------------------------ */
-static void libattopng_out_uint16(libattopng_t *png, uint16_t val) {
-    png->crc = libattopng_crc((const unsigned char *) &val, 2, png->crc);
-    libattopng_out_raw_uint16(png, val);
-}
-
-/* ------------------------------------------------------------------------ */
-static void libattopng_out_uint8(libattopng_t *png, uint8_t val) {
-    png->crc = libattopng_crc((const unsigned char *) &val, 1, png->crc);
-    libattopng_out_raw_uint8(png, val);
+//libattopng_out_uint32, libattopng_out_uint16, libattopng_out_uint8
+static void libattopng_out_size_t(libattopng_t* png, size_t val, size_t byte_count) {
+    png->crc = libattopng_crc((const unsigned char*) &val, byte_count, png->crc);
+    libattopng_out_raw_size_t(png, val, byte_count);
 }
 
 /* ------------------------------------------------------------------------ */
@@ -264,13 +250,13 @@ static void libattopng_pixel_header(libattopng_t *png, size_t offset, size_t bpl
     if (offset > bpl) {
         /* not the last line */
         libattopng_out_write(png, "\0", 1);
-        libattopng_out_uint16(png, (uint16_t) bpl);
-        libattopng_out_uint16(png, (uint16_t) ~bpl);
+        libattopng_out_size_t(png, (uint16_t) bpl, 2);
+        libattopng_out_size_t(png, (uint16_t) ~bpl, 2);
     } else {
         /* last line */
         libattopng_out_write(png, "\1", 1);
-        libattopng_out_uint16(png, (uint16_t) offset);
-        libattopng_out_uint16(png, (uint16_t) ~offset);
+        libattopng_out_size_t(png, (uint16_t) offset, 2);
+        libattopng_out_size_t(png, (uint16_t) ~offset, 2);
     }
 }
 
@@ -296,13 +282,13 @@ char *libattopng_get_data(libattopng_t *png, size_t *len) {
 
     /* IHDR */
     libattopng_new_chunk(png, "IHDR", 13);
-    libattopng_out_uint32(png, libattopng_swap32((uint32_t) (png->width)));
-    libattopng_out_uint32(png, libattopng_swap32((uint32_t) (png->height)));
-    libattopng_out_uint8(png, 8); /* bit depth */
-    libattopng_out_uint8(png, (uint8_t) png->type);
-    libattopng_out_uint8(png, 0); /* compression */
-    libattopng_out_uint8(png, 0); /* filter */
-    libattopng_out_uint8(png, 0); /* interlace method */
+    libattopng_out_size_t(png, libattopng_swap32((uint32_t) (png->width)), 4);
+    libattopng_out_size_t(png, libattopng_swap32((uint32_t) (png->height)), 4);
+    libattopng_out_size_t(png, 8, 1); /* bit depth */
+    libattopng_out_size_t(png, (uint8_t) png->type, 1);
+    libattopng_out_size_t(png, 0, 1); /* compression */
+    libattopng_out_size_t(png, 0, 1); /* filter */
+    libattopng_out_size_t(png, 0, 1); /* interlace method */
     libattopng_end_chunk(png);
 
     /* palette */
@@ -371,7 +357,7 @@ char *libattopng_get_data(libattopng_t *png, size_t *len) {
     /* checksum */
     png->s1 %= LIBATTOPNG_ADLER_BASE;
     png->s2 %= LIBATTOPNG_ADLER_BASE;
-    libattopng_out_uint32(png, libattopng_swap32((uint32_t) ((png->s2 << 16) | png->s1)));
+    libattopng_out_size_t(png, libattopng_swap32((uint32_t) ((png->s2 << 16) | png->s1)), 4);
     libattopng_end_chunk(png);
 
     /* end of image */

--- a/libattopng.c
+++ b/libattopng.c
@@ -145,6 +145,10 @@ void libattopng_put_pixel(libattopng_t* png, uint32_t color) {
     }
     x = png->stream_x;
     y = png->stream_y;
+    if ((png->capacity - 1) < (x + y * png->width)) {
+        /* ensure we don't attempt an out of bounds memory write */
+        return;
+    }
     if (png->type == PNG_PALETTE || png->type == PNG_GRAYSCALE) {
         png->data[x + y * png->width] = (char) (color & 0xff);
     } else if (png->type == PNG_GRAYSCALE_ALPHA) {

--- a/remove_test.sh
+++ b/remove_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#remove build directory created by compile_test.sh
+rm -rf ./build
+
+#check for and remove compiled binary
+[ -e libattopng ] && rm -- libattopng
+
+##check for and remove generated test images
+[ -e test_gray.png ] && rm -- test_gray.png
+[ -e test_gray_alpha.png ] && rm -- test_gray_alpha.png
+[ -e test_gray_stream.png ] && rm -- test_gray_stream.png
+[ -e test_palette.png ] && rm -- test_palette.png
+[ -e test_rgb.png ] && rm -- test_rgb.png
+[ -e test_rgba.png ] && rm -- test_rgba.png

--- a/test.c
+++ b/test.c
@@ -12,7 +12,10 @@
 
 
 int main(int argc, char *argv[]) {
-    libattopng_t *png = libattopng_new(W, H, PNG_PALETTE);
+    int x, y;
+    libattopng_t *png;
+    
+    png = libattopng_new(W, H, PNG_PALETTE);
     uint32_t palette[] = {
             RGBA(0, 0, 0xff, 0xff),
             RGBA(0, 0xff, 0, 0x80),
@@ -21,7 +24,6 @@ int main(int argc, char *argv[]) {
     };
     libattopng_set_palette(png, palette, 4);
 
-    int x, y;
     for (y = 0; y < H; y++) {
         for (x = 0; x < W; x++) {
             libattopng_set_pixel(png, x, y, (x % 16) / 4);

--- a/test.c
+++ b/test.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
             RGBA(0xff, 0, 0, 0xff),
             RGBA(0xff, 0, 0xff, 0x80)
     };
-    libattopng_set_palette(png, palette, 4);
+    libattopng_set_palette(png, palette, 16);
 
     for (y = 0; y < H; y++) {
         for (x = 0; x < W; x++) {


### PR DESCRIPTION
test_palette.png test case was written with the incorrect number of bytes provided to the libattopng_set_palette() call.  There are 4, 1 byte, numbers in each of 4 rows for the provided palette, giving a total of 16 bytes.

We can also look elsewhere in libattopng.c, to where there is a comment referencing a "minimum palette length" of 16, which means the 4 byte value in the test case doesn't even make sense.